### PR TITLE
Image custom properties and lazy loading

### DIFF
--- a/src/extensions/ImageExt.ts
+++ b/src/extensions/ImageExt.ts
@@ -80,6 +80,12 @@ export const ImageExt = Image.extend<ImageOptions>({
                 align: {
                     default: 'left',
                 },
+                'data-src': {
+                    default: ''
+                },
+                loading: {
+                    default: null
+                }
             };
         },
 
@@ -150,6 +156,8 @@ export const ImageExt = Image.extend<ImageOptions>({
                                     .insert(found[0].from, schema.nodes.image.create({
                                         src: json.data.src,
                                         alt: json.data.alt,
+                                        'data-src': json.data['data-src'],
+                                        loading: json.data.loading
                                     }))
                                     .setMeta(actionKey, {type: "remove", id}));
                             } else {

--- a/src/extensions/ImageExt.ts
+++ b/src/extensions/ImageExt.ts
@@ -81,7 +81,7 @@ export const ImageExt = Image.extend<ImageOptions>({
                     default: 'left',
                 },
                 'data-src': {
-                    default: ''
+                    default: null
                 },
                 loading: {
                     default: null


### PR DESCRIPTION
To enable lazy loading, you need to configure `loading: lazy` in the return format after the image has been successfully uploaded