### PR TITLE
fix(tiptap): 支持tiptap自定义拓展

### DIFF
--- a/src/core/AiEditor.ts
+++ b/src/core/AiEditor.ts
@@ -252,7 +252,7 @@ export class AiEditor {
         let extensions = getExtensions(this, this.options);
         if (this.options.onCreateBefore) {
             const newExtensions = this.options.onCreateBefore(this, extensions);
-            if (!newExtensions) extensions = newExtensions!;
+            if (newExtensions) extensions = newExtensions;
         }
 
         this.innerEditor = new InnerEditor(this, {


### PR DESCRIPTION
修复 #58 

顺便问下这个操作是故意的还是不小心？是因为开源协议问题阻止了对底层tiptap的拓展么？

不过 `onCreateBefore` 确实暴露了 `extensions` , 开发者依旧可以使用数组操作拓展 tiptap

```
onCreateBefore(_editor, extensions) {

  // extensions.push(自定义拓展插件);

  // 这个问题也导致使用 onCreateBefore 不返回 extensions 的话，组件报错
  return extensions;
}
```