### PR TITLE
feat(ai/custom): 自定义大模型重新支持http ReadableStream

### DIFF
--- a/src/ai/core/client/http/HttpSocketClient.ts
+++ b/src/ai/core/client/http/HttpSocketClient.ts
@@ -1,7 +1,7 @@
 import { AiClientListener } from "../../AiClientListener.ts";
 import { AiClient } from "../../AiClient.ts";
 
-type configType = { url: string, method: string }
+type configType = { url: string, method: string, headers?: Record<string, any> }
 export class HttpStreamSocketClient implements AiClient {
     isStop: boolean = false
     config: configType;
@@ -37,7 +37,7 @@ export class HttpStreamSocketClient implements AiClient {
     async send(payload: string) {
         if (this.isOpen) {
             try {
-                this.fetch = await fetch(this.config.url, { method: this.config.method, body: payload })
+                this.fetch = await fetch(this.config.url, { method: this.config.method, headers: this.config.headers, body: payload })
                 const response = this.fetch
                 if (!response.body) throw new Error("response.body is none")
 

--- a/src/ai/custom/CustomAiModel.ts
+++ b/src/ai/custom/CustomAiModel.ts
@@ -7,6 +7,7 @@ import {SseClient} from "../core/client/sse/SseClient.ts";
 import {AiClientListener} from "../core/AiClientListener.ts";
 import {WebSocketClient} from "../core/client/ws/WebSocketClient.ts";
 import {InnerEditor} from "../../core/AiEditor.ts";
+import {HttpStreamSocketClient} from "../core/client/http/HttpSocketClient.ts";
 
 export class CustomAiModel extends AiModel {
 
@@ -29,11 +30,13 @@ export class CustomAiModel extends AiModel {
                 if (aiMessage) listener.onMessage(aiMessage);
             }
         };
-        return config.protocol === "sse" ? new SseClient({
-                url,
-                method: "post",
-                headers: config.headers?.()
-            }, aiClientListener)
+        const clientConfig = {
+            url,
+            method: config.method || "post",
+            headers: config.headers?.(),
+        };
+        return config.protocol === "sse" ? new SseClient(clientConfig, aiClientListener)
+            : config.protocol === "http" ? new HttpStreamSocketClient(clientConfig, aiClientListener)
             : new WebSocketClient(url, aiClientListener)
     }
 

--- a/src/ai/custom/CustomAiModelConfig.ts
+++ b/src/ai/custom/CustomAiModelConfig.ts
@@ -3,8 +3,9 @@ import {AiMessage} from "../core/AiMessage.ts";
 
 export interface CustomAiModelConfig extends AiModelConfig {
     url: (() => string) | string,
+    method?: string;
     headers?: () => Record<string, any> | undefined,
     wrapPayload: (prompt: string) => string,
     parseMessage: (bodyString: string) => AiMessage | undefined,
-    protocol: "sse" | "websocket"
+    protocol: "sse" | "websocket" | "http"
 }


### PR DESCRIPTION
最近升级1.2.2后发现原来自定义大模型的sse方法改用`fetch-event-stream`库读取了，导致原本的 http ReadableStream 模型接口配置失效了，望重新支持一下