### PR TITLE
feat: alwaysEnabledToolbarKeys - specify always enabled menu buttons

### DIFF
--- a/src/components/AbstractMenuButton.ts
+++ b/src/components/AbstractMenuButton.ts
@@ -8,6 +8,7 @@ export class AbstractMenuButton extends HTMLElement implements AiEditorEventList
     template: string = '';
     editor?: InnerEditor;
     options?: AiEditorOptions;
+    alwaysEnabledButtons: string[] = ['fullscreen','printer'];
 
     protected constructor() {
         super();
@@ -33,6 +34,9 @@ export class AbstractMenuButton extends HTMLElement implements AiEditorEventList
     onCreate(props: EditorEvents["create"], options: AiEditorOptions): void {
         this.editor = props.editor as InnerEditor;
         this.options = options;
+        this.alwaysEnabledButtons = Array.from(
+            new Set(this.alwaysEnabledButtons.concat(options.alwaysEnabledToolbarKeys || []))
+        );
     }
 
     onTransaction(event: EditorEvents["transaction"]): void {
@@ -51,6 +55,15 @@ export class AbstractMenuButton extends HTMLElement implements AiEditorEventList
     }
 
     onEditableChange(editable: boolean) {
+        // for these menu buttons should be enabled even-if editor is NOT editable
+        let toolbarKey = this.tagName.slice(/*aie-*/4).toLocaleLowerCase();
+        if (toolbarKey === "custom") {
+            toolbarKey = this.getAttribute('id') || '';
+        }
+        if (this.alwaysEnabledButtons.includes(toolbarKey)) {
+            return;
+        }
+        
         if (!editable) {
             this.style.pointerEvents = "none"; // 禁用点击事件
             this.style.opacity = "0.5"; // 改变透明度

--- a/src/components/menus/Fullscreen.ts
+++ b/src/components/menus/Fullscreen.ts
@@ -45,7 +45,4 @@ export class Fullscreen extends AbstractMenuButton {
         }
     }
 
-    onEditableChange() {
-        //do nothing
-    }
 }

--- a/src/components/menus/Printer.ts
+++ b/src/components/menus/Printer.ts
@@ -60,10 +60,6 @@ export class Printer extends AbstractMenuButton {
         }
     }
 
-
-    onEditableChange() {
-        //do nothing
-    }
 }
 
 

--- a/src/core/AiEditor.ts
+++ b/src/core/AiEditor.ts
@@ -117,6 +117,7 @@ export type AiEditorOptions = {
     onSave?: (editor: AiEditor) => boolean,
     onFullscreen?: (isFullscreen: boolean) => void,
     toolbarKeys?: (string | CustomMenu | MenuGroup)[],
+    alwaysEnabledToolbarKeys?: string[],
     toolbarExcludeKeys?: DefaultToolbarKey[],
     toolbarSize?: 'small' | 'medium' | 'large',
     draggable?: boolean,


### PR DESCRIPTION
add an option of "alwaysEnabledToolbarKeys?: string[]" for the etidotr

for these menu buttons(toolbar keys) should be enabled even-if editor is NOT editable:
- fullscreen
- printer

and, for case of custom menu buttons, specify their "id" in "alwaysEnabledToolbarKeys".