### PR TITLE
修改基础配置 示例代码中的 pasteAsText 的层级。AiEditorOptions 类型下没有 pasteAsText

### DIFF
--- a/docs/zh/config/base.md
+++ b/docs/zh/config/base.md
@@ -12,7 +12,9 @@ new AiEditor({
     contentRetention: true,
     contentRetentionKey: 'ai-editor-content',
     draggable: true,
-    pasteAsText: false,
+    htmlPasteConfig:{
+      pasteAsText: false,
+    },
     textCounter: (text: string) => number,
     ai: {
         models: {


### PR DESCRIPTION
pasteAsText 应该在 htmlPasteConfig 下