### PR TITLE
fix: 只读模式下上传的视频不显示 (#191)

### DIFF
--- a/src/extensions/VideoExt.ts
+++ b/src/extensions/VideoExt.ts
@@ -167,13 +167,21 @@ export const VideoExt = Node.create<VideoOptions>({
 
     addNodeView() {
         return (props) => {
-            const container = document.createElement('div')
+            const {src, width, align} = props.node.attrs;
             if (!this.editor.isEditable) {
+                const container = document.createElement('video');
+                container.setAttribute('controls', 'controls');
+                container.setAttribute('width', width);
+                container.classList.add(`align-${align}`);
+                const source = document.createElement('source');
+                source.setAttribute('src', src);
+                container.appendChild(source);
+
                 return {
                     dom: container
-                }
+                };
             }
-            const {src, width, align} = props.node.attrs;
+            const container = document.createElement('div')
             container.classList.add(`align-${align}`)
             container.innerHTML = `
                   <div class="aie-resize-wrapper">


### PR DESCRIPTION
## 📌 相关问题
Fixes #191

## 📝 变更内容
- 修复了只读模式下上传的视频不显示的问题

## 🚀 变更原因
只读模式下，视频组件未正确处理数据导致页面无法正常渲染。

## 📷 测试场景
- 只读模式：确认上传的视频可以正常显示
- 非只读模式：确认视频上传和显示正常

## 📚 备注
如果还有其他问题请随时指出～